### PR TITLE
Add AST 2017

### DIFF
--- a/_data/current.yml
+++ b/_data/current.yml
@@ -141,6 +141,12 @@
   twitter: LetsTest_Conf
   status: Registration is open
 
+- name: The 12th IEEE/ACM International Workshop on Automation of Software Test (AST 2017)
+  location: Buenos Aires, Argentina
+  dates: "May 20-21, 2017"
+  url: http://tech.brookes.ac.uk/AST2017/
+  status: CFP is open until Jan. 27, 2017.
+
 - name: Workshop on Search-Based Software Testing (SBST) 2017
   location: Buenos Aires, Argentina
   dates: "May 20-28, 2017"


### PR DESCRIPTION
The 12th IEEE/ACM International Workshop on Automation of Software Test (AST 2017) will be co-host with ICSE2017.