### PR TITLE
Updated styling

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -1,6 +1,6 @@
 <div class="main-nav">
   <ul>
-    <a href="/" {% if page.url == '/index.html' %}class='active'{% endif %}>Current</a>
+    <a href="/" {% if page.url == '/' %}class='active'{% endif %}>Current</a>
     <a href="/past" {% if page.url == '/past/' %}class='active'{% endif %}>Past</a>
     <a href="/news" {% if page.url == '/news/' %}class='active'{% endif %}>News</a>
   </ul>

--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -196,6 +196,11 @@
     h2 {
       font-size: 26px;
       margin-bottom: 1px;
+      margin-left: 5px;
+    }
+
+    .fa {
+        margin-left: 10px;
     }
 }
 

--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -192,6 +192,7 @@
 
     > li {
         margin-bottom: $spacing-unit;
+        padding: 5px;
     }
 
     h2 {

--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -19,12 +19,7 @@
     margin-bottom: 0;
     float: left;
     text-shadow: 2px 2px 2px #CCC;
-
-    &,
-    &:visited {
-        color: $grey-color-dark;
     }
-}
 
 .site-nav {
     float: right;
@@ -99,7 +94,8 @@
     text-align: center;
 
     .active {
-        text-decoration: underline;
+        font-weight: bold;
+        text-decoration: none;
     }
 }
 
@@ -188,6 +184,8 @@
 .post-list {
     margin-left: 0;
     list-style: none;
+    border: 1px;
+    border-color: #e8e8e8;
 
     > li {
         margin-bottom: $spacing-unit;
@@ -201,6 +199,10 @@
 
     .fa {
         margin-left: 10px;
+    }
+
+    li:nth-child(even) {
+        background-color: #F6F6F6;
     }
 }
 

--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -96,6 +96,7 @@
     .active {
         font-weight: bold;
         text-decoration: none;
+        color:  #225c80;
     }
 }
 

--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -5,6 +5,8 @@
     border-top: 5px solid $grey-color-dark;
     border-bottom: 1px solid $grey-color-light;
     min-height: 56px;
+    background-color: #F5F5F5;
+    text-align: center;
 
     // Positioning context for the mobile navigation icon
     position: relative;
@@ -12,7 +14,7 @@
 
 .site-title {
     font-size: 50px;
-    line-height: 56px;
+    line-height: 64px;
     letter-spacing: -1px;
     margin-bottom: 0;
     float: left;
@@ -94,6 +96,7 @@
     letter-spacing: 1px;
     word-spacing: 20px;
     text-shadow: 2px 2px 2px #CCC;
+    text-align: center;
 
     .active {
         text-decoration: underline;

--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -17,7 +17,6 @@
     line-height: 64px;
     letter-spacing: -1px;
     margin-bottom: 0;
-    float: left;
     text-shadow: 2px 2px 2px #CCC;
     }
 
@@ -96,7 +95,10 @@
     .active {
         font-weight: bold;
         text-decoration: none;
-        color:  #225c80;
+    }
+
+    a {
+        color: #225c80
     }
 }
 


### PR DESCRIPTION
Lots of styling improvements compared to production. Old / current site:

![screen shot 2017-02-19 at 7 06 59 pm](https://cloud.githubusercontent.com/assets/6896787/23110496/b122f030-f6d6-11e6-9884-11fa426aaa91.png)

New styling improvements:

![screen shot 2017-02-19 at 7 06 49 pm](https://cloud.githubusercontent.com/assets/6896787/23110500/b733191e-f6d6-11e6-8467-fb0776f07613.png)

- We've centered the title and added a slight background
- Centered the navigation, changed it's color and bolded the current page
- Added a slight gray border for every other event. Indented the date line, spacing between each icon is now wider.
- Added some padding between events
- Small improvements are the key!