### PR TITLE
Adding OnlineTestConf spring 2017

### DIFF
--- a/_data/current.yml
+++ b/_data/current.yml
@@ -158,6 +158,13 @@
   url: http://cfp.testingcup.com/register_speaker
   twitter: TestingCup
   status: CFP is open
+  
+  - name: Spring OnlineTestConf
+  location: worldwide (online conference)
+  dates: "June 13-14, 2017"
+  url: http://www.onlinetestconf.com/
+  twitter: OnlineTestConf
+  status: CFP is open, Registration is open
 
 - name: US Agile Testing Days (ATD) 2017
   location: Boston, MA, USA


### PR DESCRIPTION
OnlineTestConf is an initiative to bring all the advantages of attending professional QA realted conferences: personal learning, networking etc. without the shortcomings of scheduling, expenses and travel. 

Attendance at OnlineTestConf is free and meant for anyone who sees themselves involved in testing and the testing community.  