### PR TITLE
Update current.yml

### DIFF
--- a/_data/current.yml
+++ b/_data/current.yml
@@ -56,6 +56,13 @@
   dates: "May 25-26, 2017"
   url: https://skillsmatter.com/conferences/8189-london-tester-tutorials-2017
   status: Registration is open
+  
+- name: Heisenbug 2017 Piter
+  location: Saint Petersburg, Russia
+  dates: "June 4, 2017"
+  url: https://heisenbug-piter.ru/en/
+  twitter: HeisenbugConf
+  status: Registration is open 
 
 - name: SauceCon 2017
   location: San Francisco, CA, USA


### PR DESCRIPTION
Hi!

I  propose to add the Heisenbug 2017 Piter conference to the list:

+- name: Heisenbug 2017 Piter
+  location: Saint Petersburg, Russia
+  dates: "June 4, 2017"
+  url: https://heisenbug-piter.ru/en/
+  twitter: HeisenbugConf
+  status: Registration is open 

Thanks!