### PR TITLE
Update current.yml

### DIFF
--- a/_data/current.yml
+++ b/_data/current.yml
@@ -216,9 +216,9 @@
 - name: TestBash Brighton 2018
   location: Brighton, England
   dates: "March 15-16, 2018"
-  url: https://www.ministryoftesting.com/2017/06/testbash-brighton-2018-come/
+  url: https://ti.to/mot/testbash-brighton-2018?source=testingconferences
   twitter: ministryoftest
-  status: CFP is open
+  status: Registration is open
 
 - name: STPCon Spring 2018
   location: Newport Beach, CA


### PR DESCRIPTION
changed Brighton to be on sale and change the link to a details page with a tracker for testingconferences.org