### PR TITLE
FIX: remove hyphen. title not showing up(?)

### DIFF
--- a/_data/current.yml
+++ b/_data/current.yml
@@ -53,7 +53,7 @@
   twitter: EuroTestingConf
   status: Registration is open
 
-- nam: Assert(js) 2018 - an all JavaScript Testing Conference
+- nam: Assert(js) 2018 an all JavaScript Testing Conference
   location: San Antonio, TX, USA
   dates: "February 22, 2018"
   url: https://www.assertjs.com/

--- a/_data/current.yml
+++ b/_data/current.yml
@@ -53,7 +53,7 @@
   twitter: EuroTestingConf
   status: Registration is open
 
-- nam: Assert(js) 2018 an all JavaScript Testing Conference
+- name: Assert(js) 2018 an all JavaScript Testing Conference
   location: San Antonio, TX, USA
   dates: "February 22, 2018"
   url: https://www.assertjs.com/


### PR DESCRIPTION
- I think the hyphen in the name of the conference caused the title to not render :(