### PR TITLE
Updating CFP deadline for SeConf Chicago

### DIFF
--- a/_data/current.yml
+++ b/_data/current.yml
@@ -182,7 +182,7 @@
   dates: "October 18-19, 2018"
   url: http://seleniumconf.us/
   twitter: seleniumconf
-  status: CFP is open until 10. May 2018, Registration is open
+  status: CFP is open until 25. May 2018, Registration is open
 
 - name: Argentesting 2018
   location: Buenos Aires, Argentina


### PR DESCRIPTION
According to https://www.seleniumconf.com/, the deadline is May 25th, 2018.

![image](https://user-images.githubusercontent.com/5992658/39948570-e70e2296-5576-11e8-84c9-98fb73ebff73.png)
