### PR TITLE
Add Luxembourg Software Testing Event 2018

### DIFF
--- a/_data/current.yml
+++ b/_data/current.yml
@@ -105,10 +105,10 @@
   twitter: Quest_4_Quality
   status: Registration is open
   
-  name: Luxembourg Software Testing Event 2018
+- name: Luxembourg Software Testing Event 2018
   location: Luxembourg-city, Luxembourg
   dates: "October 4, 2018"
-  url: www.lste.lu
+  url: https://www.lste.lu
   twitter: qleap_sa
   status: Registration is open
 

--- a/_data/current.yml
+++ b/_data/current.yml
@@ -104,6 +104,13 @@
   url: http://questforquality.eu/
   twitter: Quest_4_Quality
   status: Registration is open
+  
+  name: Luxembourg Software Testing Event 2018
+  location: Luxembourg-city, Luxembourg
+  dates: "October 4, 2018"
+  url: www.lste.lu
+  twitter: qleap_sa
+  status: Registration is open
 
 - name: Test Automation & Digital QA Summit 2018
   location: Hong Kong, Hong Kong


### PR DESCRIPTION
Following content was added : 

  name: Luxembourg Software Testing Event 2018
  location: Luxembourg-city, Luxembourg
  dates: "October 4, 2018"
  url: www.lste.lu
  twitter: qleap_sa
  status: Registration is open