### PR TITLE
Add TestBash Netherlands 2019

### DIFF
--- a/_data/current.yml
+++ b/_data/current.yml
@@ -345,3 +345,10 @@
   url: https://ministryoftesting.com/news/testbash-brighton-2019
   twitter: ministryoftest
   status: CFP Open until August 17, 2018
+
+- name: TestBash Netherlands 2019
+  location: Utrecht, NL
+  dates: "May 23-24, 2019"
+  url: https://ministryoftesting.com/news/testbash-netherlands-2019
+  twitter: ministryoftest
+  status: CFP Open until October 14, 2018


### PR DESCRIPTION
Adding information about newly announced TestBash Netherlands 2019, including the call for papers and link to event format.