### PR TITLE
Add TestBash Germany 2019

### DIFF
--- a/_data/current.yml
+++ b/_data/current.yml
@@ -215,3 +215,10 @@
   url: https://www.associationforsoftwaretesting.org/conference/cast2019/
   twitter: AST_News
   status: CFP is Open until February 10, 2019
+  
+- name: TestBash Germany 2019
+  location: Munich, Germany
+  dates: "September 12-13, 2019"
+  url: https://ministryoftesting.com/events/testbash-germany-2019
+  twitter: ministryoftest
+  status: CFP is Open until January 31st, 2019


### PR DESCRIPTION
Call for papers for TestBash Germany 2019 opened today.