### PR TITLE
Updating Ministry of Testing events

### DIFF
--- a/_data/current.yml
+++ b/_data/current.yml
@@ -137,7 +137,7 @@
 - name: TestBash Netherlands 2019
   location: Utrecht, NL
   dates: "May 23-24, 2019"
-  url: https://ministryoftesting.com/news/testbash-netherlands-2019
+  url: https://ti.to/mot/testbash-netherlands-2019?source=testingconferences
   twitter: ministryoftest
   status: Registration is open
 
@@ -182,6 +182,12 @@
   url: http://agiletestingdays.us/
   twitter: AgileTDUSA
   status: CFP is Closed
+  
+- name: London Tester Gathering Workshops 2019
+  location: London, UK
+  dates: "June 26-28, 2019"
+  url: https://ministryoftesting.com/events/london-tester-gathering-workshops-2019
+  twitter: ministryoftest
 
 - name: Conference for the Association for Software Testing (CAST) 2019
   location: Cocoa Beach, FL, USA


### PR DESCRIPTION
Updated the link for TestBash Netherlands to the ticket landing page. Also added London Tester Gathering Workshop dates. Registration is opening soon so left the status as blank until it does.