### PR TITLE
added 'OnlineTestConf' to the list of current conferences

### DIFF
--- a/_data/current.yml
+++ b/_data/current.yml
@@ -73,6 +73,13 @@
   twitter: nordictestdays
   status: Registration is open
 
+- name: OnlineTestConf 2019
+  location: Online
+  dates: "June 5-6, 2019"
+  url: https://www.onlinetestconf.com/?utm_source=testingconferences
+  twitter: OnlineTestConf
+  status: Registration is open
+
 - name: TestingCup 2019
   location: Poznań, Poland
   dates: "June 10-11, 2019"


### PR DESCRIPTION
OnlineTestConf is an initiative to bring all the advantages of attending professional QA related conferences: personal learning, networking etc. without the shortcomings of scheduling, expenses and travel. Attendance at OnlineTestConf is free and meant for anyone who sees themselves involved in testing and the testing community.

