### PR TITLE
Changed location of DEWT 9

### DIFF
--- a/_data/current.yml
+++ b/_data/current.yml
@@ -24,7 +24,7 @@
   status: Registration is Open
 
 - name: Dutch Exploratory Workshop on Testing Conference #9 (DEWT9)
-  location: Cambridge, UK
+  location: Driebergen, Netherlands
   dates: "January 31 - February 2, 2020"
   url: https://dewt.wordpress.com/2019/08/05/dewt-9-announcement/
   status: Applications are Open 


### PR DESCRIPTION
to match announcement on linked url https://dewt.wordpress.com/2019/08/05/dewt-9-announcement/

CEWT Is in Cambridge, DEWT in NL. I may be wrong: it could be that they've moved intentionally and they've not changed the announcement. I searched for #DEWT9 twitter and found nothing from the gang, so I expect that the cambs data is a mixup.