### PR TITLE
Updated conferences as of September, 23 2020 and created post with videos from 2019

### DIFF
--- a/_data/current.yml
+++ b/_data/current.yml
@@ -1,37 +1,3 @@
-- name: TestCon Moscow 2020
-  location: Moscow, Russia
-  dates: "September 15-17, 2020"
-  url: https://testconf.ru/?utm_source=testingconferences
-  status: Registration is Open
-
-- name: Test & Quality Summit 2020
-  location: Online
-  dates: "September 16, 2020"
-  url: https://testqualitysummit.com/?utm_source=testingconferences&utm_medium=referral
-  twitter: TQSummit
-  status: Registration is Open and Free
-
-- name: The Future of Testing 2020
-  location: Online
-  dates: "September 17, 2020"
-  url: https://applitools.com/future-of-testing-north-america/?utm_source=testingconferences
-  twitter: applitools
-  status: Registration is Open and Free
-
-- name: WeTest.Athens 2020
-  location: Athens, Greece
-  dates: "September 17, 2020"
-  url: https://wetest-athens.gr/?utm_source=testingconferences
-  twitter: WetestA
-  status: Cancelled
-
-- name: Test Automation Days 2020
-  location: Utrecht, Netherlands
-  dates: "September 22-23, 2020"
-  url: https://www.testautomationdays.com?utm_source=testingconferences
-  twitter: testautomationd
-  status: Registration is Open
-
 - name: QA Financial Digital Forum USA 2020
   location: Online
   dates: "September 23-24, 2020"
@@ -157,6 +123,18 @@
   dates: "October 14-16, 2020"
   url: https://conference.unicom.co.uk/expo/2020/?utm_source=testingconferences
   twitter: UNICOMSeminars
+  status: Registration is Open
+
+- name: QAASP
+  location: Online
+  dates: "October 16, 2020"
+  url: https://qaasp.tech
+  status: Registration is Open, CFP is Open
+
+- name: Quality Assurance Day
+  location: Online
+  dates: "October 17, 2020"
+  url: https://online.qaday.org/?utm_source=testingconferences
   status: Registration is Open
 
 - name: Let's Test (South Africa)
@@ -365,6 +343,12 @@
   url: https://waset.org/software-system-testing-and-quality-assurance-conference-in-april-2020-in-new-york?utm_source=testingconferences
   status: CFP is Open until December 30, 2020
 
+- name: SQA Days - 28
+  location: St. Petersburg, Russia
+  dates: "May 21-22, 2021"
+  url: https://sqadays.com/en/index?eventId=82473?utm_source=testingconferences
+  status: CFP is Open
+
 - name: ICSSTA 2021 - International Conference on Software System Testing and Applications
   location: London, UK
   dates: "May 24-25, 2021"
@@ -423,6 +407,11 @@
   location: Oxon Hill, MD, USA
   dates: "August 30-September 2, 2021"
   url: https://www.autotestcon.com?utm_source=testingconferences
+
+- name: QA Fest 2021
+  location: Kyiv, Ukraine
+  dates: "September, 2021"
+  url: http://qafest.com/en?utm_source=testingconferences
 
 - name: Agile & Automation Days 2021 (AADays)
   location: Poznan, Poland

--- a/_data/past.yml
+++ b/_data/past.yml
@@ -1,3 +1,32 @@
+- name: Test Automation Days 2020
+  location: Utrecht, Netherlands
+  dates: "September 22-23, 2020"
+  url: https://www.testautomationdays.com?utm_source=testingconferences
+  twitter: testautomationd
+
+- name: WeTest.Athens 2020
+  location: Athens, Greece
+  dates: "September 17, 2020"
+  url: https://wetest-athens.gr/?utm_source=testingconferences
+  twitter: WetestA
+
+- name: The Future of Testing 2020
+  location: Online
+  dates: "September 17, 2020"
+  url: https://applitools.com/future-of-testing-north-america/?utm_source=testingconferences
+  twitter: applitools
+
+- name: Test & Quality Summit 2020
+  location: Online
+  dates: "September 16, 2020"
+  url: https://testqualitysummit.com/?utm_source=testingconferences&utm_medium=referral
+  twitter: TQSummit
+
+- name: TestCon Moscow 2020
+  location: Moscow, Russia
+  dates: "September 15-17, 2020"
+  url: https://testconf.ru/?utm_source=testingconferences
+
 - name: QA Challenge Accepted 6.0
   location: Sofia, Bulgaria
   dates: "September 12, 2020"
@@ -168,7 +197,6 @@
   location: Brno, Czech Republic
   dates: "May 19, 2020"
   url: https://www.tesena.com/tesena-fest/?utm_source=testingconferences
-  status: Cancelled
 
 - name: SauceCon Online 2020
   location: Online
@@ -317,7 +345,6 @@
   location: London, UK
   dates: "March 12, 2020"
   url: https://www.qa-financial.com/events/the-qa-financial-forum-london-2020/?utm_source=testingconferences
-  status: Registration is Open
 
 - name: JaSST'20 Tokyo
   location: Tokyo, Japan
@@ -474,6 +501,7 @@
   location: Moscow, Russia
   dates: "December 4-5, 2019"
   url: https://heisenbug-moscow.ru/?utm_source=testingconferences
+  video_url: https://www.youtube.com/playlist?list=PLsVTVVvrKX9tyVb79MeUZAox5OTInS1wE
 
 - name: The QA E-commerce Forum London 2019
   location: London, UK
@@ -501,6 +529,7 @@
   dates: "November 20-22, 2019"
   url: http://contest-nyc.testmastersacademy.org/?utm_source=testingconferences
   twitter: TestMastersAcad
+  video_url: https://contest-nyc.testmastersacademy.org/videos/
 
 - name: ParisTestConf 2019
   location: Paris, France
@@ -513,6 +542,7 @@
   dates: "November 15-16, 2019"
   url: https://sqadays.com?utm_source=testingconferences
   twitter: sqadays
+  video_url: https://vimeo.com/groups/623307/videos
 
 - name: The QA E-commerce Forum New York 2019
   location: New York, NY USA
@@ -618,6 +648,7 @@
   dates: "October 15-17, 2019"
   url: http://www.testcon.lt/?utm_source=testingconferences
   twitter: TestConEurope
+  video_url: https://www.youtube.com/playlist?list=PLqYhGsQ9iSEp_0P0RdZZ2z9Oo39vf2v5I
 
 - name: Pacific Northwest Software Quality Conference (PNSQC) 2019
   location: Portland, Oregon, USA
@@ -639,6 +670,7 @@
   location: London, UK
   dates: "October 7-8, 2019"
   url: https://2019.seleniumconf.co.uk/?utm_source=testingconferences
+  video_url: https://www.youtube.com/playlist?list=PLRdSclUtJDYXLzxGo9yjcLPDuoNGWkj6t
 
 - name: Test.bash(); 2019
   location: Manchester, UK
@@ -680,7 +712,6 @@
   location: Minsk, Belarus
   dates: "September 27, 2019"
   url: http://qaasp.tech/en?utm_source=testingconferences
-  status: Registration is Open
 
 - name: STeP-IN SUMMIT Pune (PSTC) 2019
   location: Pune, India
@@ -716,6 +747,7 @@
   location: Kyiv, Ukraine
   dates: "September 20-21, 2019"
   url: http://www.qafest.com/?utm_source=testingconferences
+  video_url: https://www.youtube.com/playlist?list=PLuOBDBq7MW70q24thB9tidD2-2Tysf8FS
 
 - name: TestBash Germany 2019
   location: Munich, Germany
@@ -855,18 +887,21 @@
   dates: "June 5-6, 2019"
   url: https://www.onlinetestconf.com/?utm_source=testingconferences
   twitter: OnlineTestConf
+  video_url: https://www.youtube.com/channel/UCaCnJXHUu2qg6-uhRTG2hSg
 
 - name: SQA Days - 25 2019
   location: Saint Petersburg, Russia
   dates: "May 31-June 1, 2019"
   url: https://sqadays.com/ru/index?eventId=69279
   twitter: sqadays
+  video_url: https://vimeo.com/groups/592094/videos
 
 - name: Nordic Testing Days (NTD) 2019
   location: Tallinn, Estonia
   dates: "May 29-31, 2019"
   url: http://nordictestingdays.eu/?utm_source=testingconferences
   twitter: nordictestdays
+  video_url: https://www.youtube.com/playlist?list=PLF_V0R0nbO9y-yG4VtZN535cp1c2xpWEG
 
 - name: Workshop on Performance and Reliability (WOPR) 28
   location: Marseille, France
@@ -878,40 +913,36 @@
   location: Melbourne CBD, AUS
   dates: "May 24, 2019"
   url: http://attac.tech/?utm_source=testinconferences
-  status: Registration is Open
 
 - name: Accelerate San Francisco (formerly Quality Jam)
   location: San Francisco, CA, USA
   dates: "May 23-24, 2019"
   url: https://www.qualityjam.com/atlanta/?utm_source=testingconferences
   twitter: Tricentis
-  status: Registration is Open
 
 - name: TestBash Netherlands 2019
   location: Utrecht, NL
   dates: "May 23-24, 2019"
   url: https://ti.to/mot/testbash-netherlands-2019?source=testingconferences
   twitter: ministryoftest
-  status: Registration is Open
 
 - name: National Software Testing Conference 2019
   location: London, England
   dates: "May 21-22, 2019"
   url: http://www.softwaretestingconference.com/?utm_source=testingconferences
   twitter: testmagazine
-  status: Registration is open
 
 - name: Secure Guild Online Conference 2019
   location: Online
   dates: "May 20-21, 2019"
   url: https://guildconferences.com/product/secure-guild-2019-event-ticket/?utm_source=testinconferences
   twitter: AutomationGuild
-  status: Registration is Open
 
 - name: Heisenbug Piter
   location: Saint-Petersburg, Russia
   dates: "May 17-18, 2019"
   url: https://heisenbug-piter.ru?utm_source=testingconferences
+  video_url: https://www.youtube.com/playlist?list=PLsVTVVvrKX9szOL0VQbKNRGYib8Dqckg3
 
 - name: QAI QUEST 2019
   location: Chicago, IL, USA
@@ -924,7 +955,7 @@
   dates: "May 13-14, 2019"
   url: http://testinguy.org
   twitter: testingUY
-  video_url: https://www.youtube.com/watch?v=rQIWY4KgBqo&list=PLLjZRlRbO78vorqTndmCSCYJnGQhSqVmD
+  video_url: https://www.youtube.com/playlist?list=PLLjZRlRbO78vorqTndmCSCYJnGQhSqVmD
 
 - name: IEEE DTS 2019
   location: Gammarth, Tunisia
@@ -936,6 +967,7 @@
   dates: "April 29-May 1, 2019"
   url: https://evntestingdays.com?utm_source=testingconferences
   twitter: evntestingdays
+  video_url: https://www.youtube.com/playlist?list=PLVDq_bBMeqo3CvumRw231DzWMOepoShIL
 
 - name: STAREAST 2019
   location: Orlando, Florida, USA
@@ -984,6 +1016,7 @@
   dates: "April 18-19, 2019"
   url: https://conf.selenium.jp/?utm_source=testingconferences
   twitter: seleniumconf
+  video_url: https://www.youtube.com/playlist?list=PLItJNH7uWaWDm7saQ9xXDYn4msTARDI-M
 
 - name: TestIstanbul 2019
   location: Istanbul, Turkey
@@ -1048,11 +1081,16 @@
   url: https://ti.to/mot/testbash-brighton-2019?source=testingconferences
   twitter: ministryoftest
 
+- name: TestCon Moscow 2019
+  location: Moscow, Russia
+  dates: "April 18-19, 2018"
+  url: http://testconf.ru/
+  video_url: https://www.youtube.com/playlist?list=PLqYhGsQ9iSErkxMxToeOgxa5eJnpV2laj
+
 - name: The QA Financial Forum Chicago 2019
   location: Chicago, IL, USA
   dates: "April 2, 2019"
   url: https://www.qa-financial.com/events/the-qa-financial-forum-chicago-2019?utm_source=testingconferences
-  status: Registration is open
 
 - name: STPCon Spring 2019
   location: San Francisco, CA, USA
@@ -1071,6 +1109,7 @@
   dates: "March 22-23, 2019"
   url: https://sqadays.eu/en/index?eventId=57812
   twitter: sqadays
+  video_url: https://vimeo.com/channels/1447283/videos
 
 - name: Swiss Testing Day 2019
   location: Zurich, Switzerland
@@ -1495,7 +1534,6 @@
   location: Online
   dates: "June 20-22, 2018"
   url: https://guildconferences.com/product/testing-guild-2018-online-ticket/
-  status: Registration is open
 
 - name: Test Automation Day 2018
   location: Rotterdam, the Netherlands
@@ -2246,14 +2284,12 @@
   dates: "February 24-25, 2017"
   url: http://seleniumcamp.com/
   twitter: seleniumcamp
-  status: Registration is open
 
 - name: Conference for the Association for Software Testing (CASTx) 17
   location: Sydney, Australia
   dates: "February 20-21, 2017"
   url: https://www.associationforsoftwaretesting.org/conference/castx17/packages-and-pricing/
   twitter: AST_News
-  status: Registration is open
 
 - name: Workshop on Performance and Reliability (WOPR) 25
   location: Wellington, New Zealand
@@ -2272,7 +2308,6 @@
   dates: "February 7, 2017"
   url: https://qaorthehighway.com/
   twitter: QAortheHighway
-  status: Registration is open
 
 - name: Dutch Exploratory Workshop on Testing (DEWT) 7
   location: Driebergen, the Netherlands
@@ -2316,7 +2351,6 @@
   dates: "November 29-30, 2016"
   url: http://www.onlinetestconf.com/
   twitter: OnlineTestConf
-  status: Registration is open
   video_url: https://www.youtube.com/playlist?list=PLg74w4qP0mfG6dxeLw8vrHQGu9Yt4gwp-
 
 - name: Agile & Automation Days 2016
@@ -2492,21 +2526,18 @@
   dates: "September 15-16, 2016"
   url: http://seetest.org/index.php
   twitter: SEETESTConf
-  status: Registration is closed
 
 - name: TestWest (TESTWEST) 2016
   location: Perth, Western Australia
   dates: "September 15, 2016"
   url: http://www.testwest.org
   twitter: TestWestWA
-  status: Registration is closed
 
 - name: SoCraTes 2016
   location: Soltau, Germany
   dates: "August 25-28, 2016"
   url: https://www.socrates-conference.de/
   twitter: socrates_2016
-  status: Registration is closed
 
 - name: Conference for the Association for Software Testing (CAST) 2016
   location: Vancouver, BC, Canada

--- a/_posts/2020-24-09-2019-videos.md
+++ b/_posts/2020-24-09-2019-videos.md
@@ -1,0 +1,38 @@
+---
+layout: post
+title:  "2019 Software Testing Conferences with Free Video Recordings!"
+date:   2020-09-24 10:00:00
+categories: news
+author: Uladzislau Ramanenka
+---
+
+In our list of <a href="/past" target="_blank">Past Conferences</a>, when available, we provide a link to testing conference videos that are made available freely online under the link **Event Videos** (open the page and do a quick search).
+
+We think there's an *amazing community benefit* when events record their presentations (or at least some of them) and distribute them freely on the web. We know this adds to the cost of producing and coordinating a conference because you need to equipment, transportation and personnel to do these things. As a way to highlight those conferences, promote this idea and say **Thank You** here are the 2019 software testing conferences with video recordings in *alphabetical order*:
+
+**Free Event Videos:**
+1. <a href="https://contest-nyc.testmastersacademy.org/videos/" target="_blank">ConTEST NYC 2019</a>
+1. <a href="https://www.youtube.com/playlist?list=PLsVTVVvrKX9szOL0VQbKNRGYib8Dqckg3" target="_blank">Heisenbug Piter 2019</a>
+1. <a href="https://www.youtube.com/playlist?list=PLsVTVVvrKX9tyVb79MeUZAox5OTInS1wE" target="_blank">Heisenbug Moscow 2019</a>
+1. <a href="https://www.youtube.com/playlist?list=PLF_V0R0nbO9y-yG4VtZN535cp1c2xpWEG" target="_blank">Nordic Testing Days (NTD) 2019</a>
+1. <a href="https://www.youtube.com/channel/UCaCnJXHUu2qg6-uhRTG2hSg" target="_blank">OnlineTestConf - Spring & Fall 2019</a>
+1. <a href="https://www.youtube.com/playlist?list=PLuOBDBq7MW70q24thB9tidD2-2Tysf8FS" target="_blank">QA Fest 2019</a>
+1. <a href="https://www.youtube.com/playlist?list=PL67l1VPxOnT5PZQ1r60wQoT2UPDk1of4z" target="_blank">SauceCon 2019. Day 1</a>, <a href="https://www.youtube.com/playlist?list=PL67l1VPxOnT6HbBRtFSK9nwvXbAprqttR" target="_blank">Day 2</a>
+1. <a href="https://www.youtube.com/playlist?list=PLRdSclUtJDYXLzxGo9yjcLPDuoNGWkj6t" target="_blank">SeleniumConf London 2019</a>
+1. <a href="https://www.youtube.com/playlist?list=PLItJNH7uWaWDm7saQ9xXDYn4msTARDI-M" target="_blank">SeleniumConf (SeConf) Tokyo 2019</a>
+1. <a href="https://vimeo.com/groups/592094/videos" target="_blank">SQA Days - 25</a>
+1. <a href="https://vimeo.com/groups/623307/videos" target="_blank">SQA Days - 26</a>
+1. <a href="https://vimeo.com/channels/1447283/videos" target="_blank">SQA Days EU - 1</a>
+1. <a href="https://www.youtube.com/playlist?list=PLqYhGsQ9iSEp_0P0RdZZ2z9Oo39vf2v5I" target="_blank">TestCon Europe 2019</a>
+1. <a href="https://www.youtube.com/playlist?list=PLqYhGsQ9iSErkxMxToeOgxa5eJnpV2laj" target="_blank">TestCon Moscow 2019</a>
+1. <a href="https://www.youtube.com/playlist?list=PLLjZRlRbO78vorqTndmCSCYJnGQhSqVmD" target="_blank">TestingUY 2019</a>
+1. <a href="https://www.youtube.com/playlist?list=PLVDq_bBMeqo3CvumRw231DzWMOepoShIL" target="_blank">Yerevan Testing Days 2019</a>
+
+**Other Things**
+
+- Check out <a href="/news/2017/12/12/2017-videos.html" target="_blank">2017's list of Event Videos here</a>.
+- Check out <a href="/news/2017/12/11/2016-videos.html" target="_blank">2016's list of Event Videos here</a>.
+
+Are we missing any videos? If so let us know by adding them **<a href="https://github.com/TestingConferences/testingconferences.github.io/blob/master/_data/past.yml" target="_blank">here!</a>**
+
+Don't forget to **[sign up](http://eepurl.com/c4paYT)** for our once **monthly newsletter.**


### PR DESCRIPTION
Hello,
please review the following changeset:
 - September 2020 latest conferences moved to past
 - Added few 2021 conferences
 - Removed obsolete statuses for past conferences
 - Added video_url for 2019 events
 - Created videos 2019 post (similar to 2017 one)

Thanks!