### PR TITLE
Adding ParisTestConf next conference

### DIFF
--- a/_data/current.yml
+++ b/_data/current.yml
@@ -324,6 +324,13 @@
   twitter: AgileTD
   status: CFP is Open until March 28, 2021
   
+  - name: ParisTestConf (PTC) 2021
+  location: Online
+  dates: "November 2021"
+  url: https://paristestconf.com/?utm_source=testingconferences
+  twitter: ParisTestConf
+  status: CFP is Open until June 30, 2021
+  
 - name: System Testing and Validation (STV) 2021 Workshop at IEEE QRS conference
   location: Hainan Island, China
   dates: "December 6-10, 2021"

--- a/_data/current.yml
+++ b/_data/current.yml
@@ -324,7 +324,7 @@
   twitter: AgileTD
   status: CFP is Open until March 28, 2021
   
-  - name: ParisTestConf (PTC) 2021
+- name: ParisTestConf (PTC) 2021
   location: Online
   dates: "November 2021"
   url: https://paristestconf.com/?utm_source=testingconferences

--- a/_data/past.yml
+++ b/_data/past.yml
@@ -147,7 +147,7 @@
   url: https://www.qs-tag.de/en/?utm_source=testingconferences
   twitter: SoftwareQSTag
 
-- name: Paris Test Conf 2020
+- name: ParisTestConf (PTC) 2020
   location: Online
   dates: "November 23-26, 2020"
   url: https://paristestconf.com/programme?utm_source=testingconferences


### PR DESCRIPTION
Hello,

I would like to add the next event of the ParisTestConf, which will take place in November 2021 (exact date is not yet fixed, it will be added later).
I also fixed a small typo in the name of the precedent event, for consistency reasons.

Thank you !