### PR TITLE
Update ParisTestConf status

### DIFF
--- a/_data/current.yml
+++ b/_data/current.yml
@@ -191,7 +191,6 @@
   dates: "November 22-26, 2021"
   url: https://paristestconf.com/?utm_source=testingconferences
   twitter: ParisTestConf
-  status: CFP is now closed
   
 - name: System Testing and Validation (STV) 2021 Workshop at IEEE QRS conference
   location: Hainan Island, China

--- a/_data/current.yml
+++ b/_data/current.yml
@@ -191,7 +191,7 @@
   dates: "November 22-26, 2021"
   url: https://paristestconf.com/?utm_source=testingconferences
   twitter: ParisTestConf
-  status: CFP is Open until June 30, 2021
+  status: CFP is now closed
   
 - name: System Testing and Validation (STV) 2021 Workshop at IEEE QRS conference
   location: Hainan Island, China


### PR DESCRIPTION
Hello,

just updated the status for the ParisTestConf conference: CFP is now closed.

Thanks !