### PR TITLE
Add Test Automation Days 2024 to current

### DIFF
--- a/_data/current.yml
+++ b/_data/current.yml
@@ -270,6 +270,13 @@
   twitter: TechWell
   status: CFP is Open until September 24, 2023
 
+- name: Test Automation Days 2024
+  location: Rotterdam, the Netherlands
+  dates: "May 29-30, 2024"
+  url: https://www.testautomationdays.com?utm_source=testingconferences
+  twitter: testautomationd
+  status: <a href="https://www.testautomationdays.com/call-for-cases/" target="_blank">CFP is Open</a> until January 19, 2024
+
 - name: Agile Testing Days (ATD) Open Air
   location: Germany
   dates: "June 4-6, 2024"


### PR DESCRIPTION
Hey @ckenst, this pull request is meant to add the 2024 Test Automation Days conference to the current list. Thanks for all the hard work on this!