### PR TITLE
Add Test Automation Days 2025 to the program

### DIFF
--- a/_data/current.yml
+++ b/_data/current.yml
@@ -233,6 +233,13 @@
   url: https://robocon.io/?utm_source=testingconferences
   status: Announced
 
+- name: Test Automation Days 2025
+  location: Rotterdam, the Netherlands
+  dates: "March 5-6, 2025"
+  url: https://www.testautomationdays.com?utm_source=testingconferences
+  twitter: testautomationd
+  status: Announced
+
 - name: Testing Peers Conference 2025
   location: Nottingham, UK
   dates: "March 13, 2025"


### PR DESCRIPTION
Hey Chris,

this PR adds the 2025 Test Automation Days conference to the list.