### PR TITLE
Added first time conference in Portugal.

### DIFF
--- a/_data/current.yml
+++ b/_data/current.yml
@@ -142,6 +142,12 @@
   url: https://testistanbul.org/?utm_source=testingconferences
   status: Registration is Open
 
+- name: TestSociety
+  location: Porto, Portugal
+  dates: "October 11, 2024"
+  url: https://www.testsociety.pt/?utm_source=testingconferences
+  status: Registration is Open
+
 - name: Pacific Northwest Software Quality Conference (PNSQC) 2024
   location: Portland, Oregon and Online
   dates: "October 14-16, 2024"


### PR DESCRIPTION
TestSociety is a new 1-day conference with low entry fee (30 Euro) from enthuasiasts for the community.
It will rotate each year, 2024 it will be Porto.