### PR TITLE
Add workshop on test selection in June 2025

### DIFF
--- a/_data/current.yml
+++ b/_data/current.yml
@@ -255,3 +255,9 @@
   url: https://agiletestingdays.com/?utm_source=testingconferences
   twitter: AgileTD
   status: Early Bird Registration is Open until September 21, 2025
+
+- name: "Workshop: Everyone wants to shift left, but our tests are just too slow!"
+  location: Online
+  dates: "June 25, 2025"
+  url: https://tmscl.me/ts-2025-06-tc
+  status: Registration is open

--- a/_data/current.yml
+++ b/_data/current.yml
@@ -80,7 +80,13 @@
   location: London, UK
   dates: "June 19, 2025"
   url: https://www.bcs.org/membership-and-registrations/member-communities/software-testing-specialist-group/conferences/bcs-sigist-summer-conference-2025/?utm_source=testingconferences
-  
+
+- name: "Workshop: Everyone wants to shift left, but our tests are just too slow!"
+  location: Online
+  dates: "June 25, 2025"
+  url: https://tmscl.me/ts-2025-06-tc
+  status: Registration is open
+
 - name: QA or the Highway
   location: Columbus, OH
   dates: "June 27, 2025"
@@ -255,9 +261,3 @@
   url: https://agiletestingdays.com/?utm_source=testingconferences
   twitter: AgileTD
   status: Early Bird Registration is Open until September 21, 2025
-
-- name: "Workshop: Everyone wants to shift left, but our tests are just too slow!"
-  location: Online
-  dates: "June 25, 2025"
-  url: https://tmscl.me/ts-2025-06-tc
-  status: Registration is open


### PR DESCRIPTION
Our online workshop on how to automatically select the most relevant test, to cut down test runtimes and speed up test feedback, even with long-running tests, higher-level tests and manual tests.