### PR TITLE
Corrected data of Selenium & Appium Conference 2026

### DIFF
--- a/_data/current.yml
+++ b/_data/current.yml
@@ -269,7 +269,7 @@
 
 - name: SeleniumConf & AppiumConf 2026
   location: Valencia, ES
-  dates: "March 7-8, 2026"
+  dates: "May 6-8, 2026"
   url: https://seleniumconf.com/?utm_source=testingconferences
   twitter: seleniumconf
   status: <a href="https://seleniumconf.com/submit-a-talk/?utm_source=testingconferences" target="_blank">CFP is Open</a>


### PR DESCRIPTION
According to the conference website I corrected March to May and the date

https://seleniumconf.com/

