### PR TITLE
Add new conference details for 2026

### DIFF
--- a/_data/current.yml
+++ b/_data/current.yml
@@ -191,11 +191,11 @@
   twitter: esconfs
   status: <a href="https://conference.eurostarsoftwaretesting.com/tickets/?utm_source=testingconferences" target="_blank">Early Bird</a> Pricing is Open
 
-- name: Human-Centred Testing: People and Practices & the Future of the Profession
+- name: "Human-Centred Testing: People and Practices & the Future of the Profession"
   location: London, UK
   dates: "July 7, 2026"
   url: https://www.bcs.org/membership-and-registrations/member-communities/software-testing-specialist-group/conferences/call-for-speakers/?utm_source=testingconferences
-  status: <a href="https://www.bcs.org/membership-and-registrations/member-communities/software-testing-specialist-group/conferences/call-for-speakers/?utm_source=testingconferences" target="_blank">CFP</a> is Open 
+  status: <a href="https://www.bcs.org/membership-and-registrations/member-communities/software-testing-specialist-group/conferences/call-for-speakers/?utm_source=testingconferences" target="_blank">CFP is Open</a> until March 31, 2026
 
 - name: "ICSTP 2026: International Conference on Software Testing Process"
   location: Amsterdam, Netherlands or Online


### PR DESCRIPTION
Adding SIGiST 2026 Conference


# Pull Request Template: Add a Conference or Workshop

Thank you for contributing! Most PRs are to add a new conference or workshop. The following are to help ensure you've added everything correctly:

## Conference/Workshop Details
- [ ] Name, Location, Date(s), Website URL and Status are required
- [ ] X / Twitter is Optional
- [ ] Location should be City + Country or Online
- [ ] Status can include information about registration, pricing, calls for proposals and can include links to all the above.

## Checklist
- [ ] I have added the conference/workshop to the correct YAML file (`_data/current.yml` or `_data/past.yml`)
- [ ] The entry includes name, location, date(s), url and accurate status
- [ ] The entry is in chronological order (soonest to furtherest away)
- [ ] If there are any special characters in the name field (`:` or `;` or `'`), the name must be in quotes (`"`)
- [ ] I have checked for duplicates to avoid listing the same event twice
- [ ] Build runs successfully

## Additional context
Add any other context or screenshots about the pull request here.
