### PR TITLE
Add Live2Test 2026 conference

### DIFF
--- a/_data/current.yml
+++ b/_data/current.yml
@@ -105,6 +105,12 @@
   twitter: expoqa
   status: <a href="https://expoqa.eu/ticket-shop/?utm_source=testingconferences" target="_blank">Early Bird Registration is Open</a>
 
+- name: Live2Test 2026
+  location: Online
+  dates: "June 2-3, 2026"
+  url: https://live2test.com/?utm_source=testingconferences
+  status: <a href="https://live2test.com/#tickets" target="_blank">Early Bird Tickets Available</a>
+
 - name: Nordic Testing Days
   location: Tallinn, Estonia
   dates: "June 3-5, 2026"


### PR DESCRIPTION
Hi 👋

I would like to add Live2Test 2026 to the list of upcoming software testing conferences.

**Conference Details:**
- Name: Live2Test 2026
- Dates: June 2–3, 2026
- Location: Online
- Website: https://live2test.com/

Live2Test is an international software testing conference focused on QA, test automation, and quality engineering topics, bringing together professionals from around the world.

The entry has been added to `_data/current.yml` in chronological order.

Thanks for maintaining this awesome resource!


# Pull Request Template: Add a Conference or Workshop

Thank you for contributing! Most PRs are to add a new conference or workshop. The following are to help ensure you've added everything correctly:

## Conference/Workshop Details
- [x] Name, Location, Date(s), Website URL and Status are required
- [x] X / Twitter is Optional
- [x] Location should be City + Country or Online
- [x] Status can include information about registration, pricing, calls for proposals and can include links to all the above.

## Checklist
- [x] I have added the conference/workshop to the correct YAML file (`_data/current.yml` or `_data/past.yml`)
- [x] The entry includes name, location, date(s), url and accurate status
- [x] The entry is in chronological order (soonest to furtherest away)
- [x] If there are any special characters in the name field (`:` or `;` or `'`), the name must be in quotes (`"`)
- [x] I have checked for duplicates to avoid listing the same event twice
- [x] Build runs successfully

## Additional context
Add any other context or screenshots about the pull request here.
