### PR TITLE
Add Testers Day 2026 (CFP page)

### DIFF
--- a/_data/current.yml
+++ b/_data/current.yml
@@ -176,7 +176,7 @@
   location: Tbilisi, Georgia
   dates: "September 8-9, 2026"
   url: https://geostqb.org/call-for-speakers-testers-day-2026/
-  status: <a href="https://events.summit-community.de/event/tacon-2026/tickets/?utm_source=testingconferences" target="_blank">CFP is Open</a> until May 20, 2026
+  status: <a href="https://geostqb.org/call-for-speakers-testers-day-2026/" target="_blank">CFP is Open</a> until May 20, 2026
 
 - name: TACON 2026
   location: Leipzig, Germany

--- a/_data/current.yml
+++ b/_data/current.yml
@@ -172,6 +172,12 @@
   twitter: lambdatesting
   status: <a href="https://www.testmuai.com/testmuconf-2026?utm_source=STC&utm_medium=organic&utm_content=testmu_2026" target="_blank">Registration is Open</a> | <a href="https://forms.gle/enGiaSQiX7DrCqXJ6" target="_blank">CFP is Open until May 31, 2026</a>
 
+- name: Tester's Day 2026
+  location: Tbilisi, Georgia
+  dates: "September 8-9, 2026"
+  url: https://geostqb.org/call-for-speakers-testers-day-2026/
+  status: <a href="https://events.summit-community.de/event/tacon-2026/tickets/?utm_source=testingconferences" target="_blank">CFP is Open</a> until May 20, 2026
+
 - name: TACON 2026
   location: Leipzig, Germany
   dates: "September 16-17, 2026"


### PR DESCRIPTION
It seems I’ve added everything required for the upcoming event. One note: the website currently only includes the CFP page. Details such as the agenda, venue, and a dedicated event page will be added later.
Is it okay to merge this now and update the main event link in a separate PR afterward?

## Conference/Workshop Details
- [x] Name, Location, Date(s), Website URL and Status are required
- [ ] X / Twitter is Optional
- [x] Location should be City + Country or Online
- [x] Status can include information about registration, pricing, calls for proposals and can include links to all the above.

## Checklist
- [x] I have added the conference/workshop to the correct YAML file (`_data/current.yml` or `_data/past.yml`)
- [x] The entry includes name, location, date(s), url and accurate status
- [x] The entry is in chronological order (soonest to furtherest away)
- [x] If there are any special characters in the name field (`:` or `;` or `'`), the name must be in quotes (`"`)
- [x] I have checked for duplicates to avoid listing the same event twice
- [x] Build runs successfully
